### PR TITLE
Support for '' empty sound names

### DIFF
--- a/petblocks-bukkit-plugin/src/main/kotlin/com/github/shynixn/petblocks/bukkit/logic/business/service/SoundServiceImpl.kt
+++ b/petblocks-bukkit-plugin/src/main/kotlin/com/github/shynixn/petblocks/bukkit/logic/business/service/SoundServiceImpl.kt
@@ -71,7 +71,7 @@ class SoundServiceImpl @Inject constructor(private val plugin: Plugin, private v
 
         val soundName = sound.name.toUpperCase()
 
-        if (soundName.equals("NONE", true)) {
+        if (soundName.equals("NONE", true) || soundName.equals("")) {
             return
         }
 

--- a/petblocks-sponge-plugin/src/main/java/com/github/shynixn/petblocks/sponge/logic/business/service/SoundServiceImpl.kt
+++ b/petblocks-sponge-plugin/src/main/java/com/github/shynixn/petblocks/sponge/logic/business/service/SoundServiceImpl.kt
@@ -71,7 +71,7 @@ class SoundServiceImpl @Inject constructor(private val configurationService: Con
     private fun playSoundToPlayers(location: Vector3d, sound: Sound, players: Collection<Player>) {
         val soundName = sound.name.toUpperCase()
 
-        if (soundName.equals("NONE", true)) {
+        if (soundName.equals("NONE", true) || soundName.equals("")) {
             return
         }
 


### PR DESCRIPTION
When the sound name is an empty string, no sound is played in com.github.shynixn.petblocks.bukkit.logic.business.service.SoundServiceImpl and
com.github.shynixn.petblocks.sponge.logic.business.service.SoundServiceImpl